### PR TITLE
Fix typo in variable name

### DIFF
--- a/helper/exec_lib.sh
+++ b/helper/exec_lib.sh
@@ -220,7 +220,7 @@ exec_module()
 		then
 			lib_iut_dir=${_LIB_IUT_PROD}
 		else
-			echo "Test vector base directory ${_LUB_IUT} / ${_LIB_IUT_PROD} not found"
+			echo "Test vector base directory ${_LIB_IUT} / ${_LIB_IUT_PROD} not found"
 			return
 		fi
 	fi


### PR DESCRIPTION
Just a typo I've noticed.

I didn't test the change.

Best,
~R